### PR TITLE
remove prepare script

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
     "compile": "babel src --loose --out-dir lib",
     "demos:start": "webpack-dev-server --watch",
     "demos:build": "NODE_ENV=production webpack",
-    "prepublish": "npm run prepare",
-    "prepare": "npm run clean && npm run compile",
+    "prepublish": "npm run clean && npm run compile",
     "test": "mocha test/setup.js test/spec/*.js"
   },
   "repository": {


### PR DESCRIPTION
https://github.com/yarnpkg/yarn/issues/6312#issuecomment-422806004

https://docs.npmjs.com/misc/scripts
"prepare: Run both BEFORE the package is packed and published, on local npm install without any arguments, **and when installing git dependencies** (See below). "

When we switched the dependencies to the git version, this means `yarn install` would have the prepare script below run a `npm clean` at the same time.